### PR TITLE
sim_cycle_timers: changed code to use shift-in-place with memcpy().

### DIFF
--- a/simavr/sim/sim_cycle_timers.c
+++ b/simavr/sim/sim_cycle_timers.c
@@ -60,14 +60,11 @@ avr_cycle_timer_insert(
 	when += avr->cycle;
 
 	// find its place in the list
-	int inserti = 0;
-	while (inserti < pool->count && pool->timer[inserti].when > when)
-		inserti++;
-	// make a hole
-	int cnt = pool->count - inserti;
-	if (cnt)
-		memmove(&pool->timer[inserti + 1], &pool->timer[inserti],
-				cnt * sizeof(avr_cycle_timer_slot_t));
+	int inserti = pool->count;
+	while((inserti > 0) && (pool->timer[inserti - 1].when < when)) {
+		memcpy(&pool->timer[inserti], &pool->timer[inserti-1], sizeof(avr_cycle_timer_slot_t));
+		inserti--;
+	}
 
 	pool->timer[inserti].timer = timer;
 	pool->timer[inserti].param = param;


### PR DESCRIPTION
avr_cycle_timer_insert(): double operation to perform insert has been
 changed to use a single step by reverse traversing the list and
 moving the elments as needed.  doing so allows for switch from using
 memmove() to memcpy() as the individual elements do not overlap
 using this method thus there is no reason to perform a double indirect
 copy to move as memmove does.

```
modified:   sim/sim_cycle_timers.c
```
